### PR TITLE
Update fstab.yaml to add new mountpoints for Bounteous-Inc

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,5 +1,9 @@
 mountpoints:
   /:
-    url: "https://author-p130360-e1272151.adobeaemcloud.com/bin/franklin.delivery/adobe-rnd/aem-boilerplate-xwalk/main"
+    url: "https://author-p130360-e1272151.adobeaemcloud.com/bin/franklin.delivery/Bounteous-Inc/eds-whitelabel/main"
+    type: "markup"
+    suffix: ".html"
+  /eds-newco:
+    url: "https://author-p130360-e1272151.adobeaemcloud.com/bin/franklin.delivery/Bounteous-Inc/eds-newco/main"
     type: "markup"
     suffix: ".html"


### PR DESCRIPTION


Fix #Update fstab.yaml to add new mountpoints for Bounteous-Inc

Test URLs:
- Before: https://main--eds-multisite-boilerplate--bounteous-inc.aem.live/
- After: https://fstab--eds-multisite-boilerplate--bounteous-inc.aem.live/
