### PR TITLE
Remove unused mountpoint for /eds-newco in fstab.yaml

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -3,7 +3,3 @@ mountpoints:
     url: "https://author-p28206-e1206067.adobeaemcloud.com/bin/franklin.delivery/Bounteous-Inc/eds-whitelabel/main"
     type: "markup"
     suffix: ".html"
-  /eds-newco:
-    url: "https://author-p28206-e1206067.adobeaemcloud.com/bin/franklin.delivery/Bounteous-Inc/eds-newco/main"
-    type: "markup"
-    suffix: ".html"


### PR DESCRIPTION
Fix #Update fstab.yaml to add new mountpoints for Bounteous-Inc

Test URLs:

Before: https://main--eds-multisite-boilerplate--bounteous-inc.aem.live/
After: https://fstab-update--eds-multisite-boilerplate--bounteous-inc.aem.live/