### PR TITLE
Update URL in fstab.yaml for Bounteous-Inc mountpoint

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,5 +1,5 @@
 mountpoints:
   /:
-    url: "https://author-p28206-e1206067.adobeaemcloud.com/bin/franklin.delivery/Bounteous-Inc/eds-multisite-boilerplate/main"
+    url: "https://author-p28206-e1206067.adobeaemcloud.com/bin/franklin.delivery/Bounteous-Inc/eds-whitelabel/main"
     type: "markup"
     suffix: ".html"


### PR DESCRIPTION
Fix #Update fstab.yaml to add new mountpoints for Bounteous-Inc

Test URLs:

Before: https://main--eds-multisite-boilerplate--bounteous-inc.aem.live/
After: https://fstab-update--eds-multisite-boilerplate--bounteous-inc.aem.live/