### PR TITLE
Add config.json for EDS Whitelabel site configuration

### DIFF
--- a/.helix/config.json
+++ b/.helix/config.json
@@ -1,0 +1,17 @@
+{
+  "mountpoints": [
+    {
+      "path": "/",
+      "url": "https://author-p28206-e1206067.adobeaemcloud.com/bin/franklin.delivery/Bounteous-Inc/eds-whitelabel/main",
+      "type": "markup",
+      "suffix": ".html"
+    }
+  ],
+  "site": {
+    "title": "EDS Whitelabel",
+    "languages": ["en"]
+  },
+  "editor": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
Fix #Update fstab.yaml to add new mountpoints for Bounteous-Inc

Test URLs:

Before: https://main--eds-multisite-boilerplate--bounteous-inc.aem.live/
After: https://fstab-update--eds-multisite-boilerplate--bounteous-inc.aem.live/