### PR TITLE
Update paths.json to replace 'whitelabel' with 'starter' for correct …

### DIFF
--- a/paths.json
+++ b/paths.json
@@ -1,10 +1,9 @@
 {
   "mappings": [
-    "/content/eds-multisite-whitelabel/:/",
-    "/content/eds-multisite-whitelabel/configuration:/.helix/config.json",
-    "/content/eds-multisite-whitelabel/metadata:/metadata.json"
+    "/content/eds-multisite-starter/:/",
+    "/content/eds-multisite-starter/metadata:/metadata.json"
   ],
   "includes": [
-    "/content/eds-multisite-whitelabel/"
+    "/content/eds-multisite-starter/"
   ]
 }


### PR DESCRIPTION
Fix #Update fstab.yaml to add new mountpoints for Bounteous-Inc

Test URLs:

Before: https://main--eds-multisite-boilerplate--bounteous-inc.aem.live/
After: https://fstab-update--eds-multisite-boilerplate--bounteous-inc.aem.live/